### PR TITLE
Add end var in dispatcher tests

### DIFF
--- a/.github/workflows/_dispatcher_common.yml
+++ b/.github/workflows/_dispatcher_common.yml
@@ -53,3 +53,4 @@ jobs:
         run: pytest
         env:
           TRACING_ENABLED: ${{ vars.TRACING_ENABLED }}
+          GCP_ENVIRONMENT_ENABLED: ${{ vars.GCP_ENVIRONMENT_ENABLED }}


### PR DESCRIPTION
This PR passes a new env var to unit tests for the dispatchers pipeline. This var allows to mock some GCP services when running in the CI, to avoid them failing.