### PR TITLE
fix(gke): switch to Connect Gateway for cluster credentials

### DIFF
--- a/.github/workflows/deploy_k8s.yml
+++ b/.github/workflows/deploy_k8s.yml
@@ -51,7 +51,9 @@ jobs:
     - uses: google-github-actions/get-gke-credentials@v2
       with:
         cluster_name: ${{ vars.GKE_CLUTER_NAME }}
-        location: 'us-central1'
+        location: global
+        use_connect_gateway: 'true'
+        project_id: serca-tools
     - uses: azure/setup-helm@v3
       with:
           version: 'v3.12.0'

--- a/.github/workflows/update_k8s_image.yml
+++ b/.github/workflows/update_k8s_image.yml
@@ -45,8 +45,9 @@ jobs:
     - uses: google-github-actions/get-gke-credentials@v2
       with:
         cluster_name: ${{ vars.GKE_CLUTER_NAME }}
-        project_id: ${{ vars.PROJECT_ID }}
-        location: ${{ vars.LOCATION }}
+        location: global
+        use_connect_gateway: 'true'
+        project_id: serca-tools
     - run: |
         kubectl set image deployment/${{ inputs.deployment }} ${{ inputs.container }}=${{ inputs.repository }}:${{ inputs.tag }} -n ${{ inputs.namespace }}
 


### PR DESCRIPTION
## Summary

Switches both K8s deploy workflows from direct cluster endpoint access to GKE Fleet Connect Gateway, fixing failures after master authorized networks were restricted on Gundi clusters.

## Changes

### Changed
- \`deploy_k8s.yml\`: replace \`location: us-central1\` with \`location: global\`, \`use_connect_gateway: true\`, \`project_id: serca-tools\`
- \`update_k8s_image.yml\`: same — replace \`project_id: \${{ vars.PROJECT_ID }}\` and \`location: \${{ vars.LOCATION }}\` with Connect Gateway config

## Technical Details

The Gundi GKE clusters now have restricted master authorized networks (GitHub Actions runner IPs are blocked). Connect Gateway routes through the GKE Fleet in \`serca-tools\` using IAM instead of network-level access — no IP allowlisting needed.

Requires companion IAM change in \`serca-iac\` (PR open): grant \`roles/gkehub.gatewayEditor\` on \`serca-tools\` to all Gundi GHA SAs. The \`GKE_CLUTER_NAME\` env var already matches the fleet membership name (\`gundi-dev\`, \`gundi-stage\`, \`gundi-prod\`), so no GitHub environment variable updates needed.

## Files Changed

**2 files changed, 6 insertions(+), 3 deletions(-)**