### PR TITLE
feat(DASOPS-2057): support Direct WIF auth in build_docker.yml + BuildKit mirror

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -54,23 +54,34 @@ jobs:
       with:
         name: ${{ inputs.artifact-name }}
         path: ${{ inputs.artifact-path }}
-    - name: GCP Auth
+    - name: GCP Auth (SA-based)
       id: auth
+      if: ${{ env.SERVICE_ACCOUNT != '' }}
       uses: google-github-actions/auth@v2
       with:
         token_format: 'access_token'
         workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
         service_account: ${{ env.SERVICE_ACCOUNT }}
+    - name: GCP Auth (Direct WIF)
+      id: auth_direct
+      if: ${{ env.SERVICE_ACCOUNT == '' }}
+      uses: google-github-actions/auth@v2
+      with:
+        token_format: 'access_token'
+        workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
     - name: Login to GAR
       uses: docker/login-action@v3
       with:
         registry: ${{ inputs.repository }}
         username: oauth2accesstoken
-        password: ${{ steps.auth.outputs.access_token }}
+        password: ${{ steps.auth.outputs.access_token || steps.auth_direct.outputs.access_token }}
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
+      with:
+        driver-opts: |
+          image=europe-west3-docker.pkg.dev/serca-artifact-registry/virtual-docker/moby/buildkit:buildx-stable-1
     - name: Build and push
       uses: docker/build-push-action@v5
       with:


### PR DESCRIPTION
## Summary

Split the GCP Auth step into conditional SA-based and Direct WIF paths, and configure BuildKit to pull its image from the serca-artifact-registry virtual-docker mirror.

## Changes

### Changed
- Split single "GCP Auth" step into two conditional steps: SA-based (when `SERVICE_ACCOUNT != ''`) and Direct WIF (when `SERVICE_ACCOUNT == ''`) — same pattern as `serca-pipelines/_docker-build.yml`
- Docker login now uses `steps.auth.outputs.access_token || steps.auth_direct.outputs.access_token` to support either auth path
- BuildKit image now pulls from `europe-west3-docker.pkg.dev/serca-artifact-registry/virtual-docker/moby/buildkit:buildx-stable-1` to avoid DockerHub rate limits

## Technical Details

The previous workflow always passed `service_account` to `google-github-actions/auth@v2` even when the input was empty (fell back to `vars.SERVICE_ACCOUNT`), blocking Direct WIF usage. The fix mirrors what `serca-pipelines/_docker-build.yml` already does for ER repos.

After merge: create tag `v9` so Gundi app CI workflows can reference this version.

## Files Changed

**1 file changed, 11 insertions(+), 5 deletions(-)**

---
**Jira**: https://padas.atlassian.net/browse/DASOPS-2057