### PR TITLE
ci(DASOPS-2057): use direct GKE credentials in update_k8s_image

### DIFF
--- a/.github/workflows/update_k8s_image.yml
+++ b/.github/workflows/update_k8s_image.yml
@@ -45,7 +45,7 @@ jobs:
     - uses: google-github-actions/setup-gcloud@v2
       with:
         install_components: 'kubectl,gke-gcloud-auth-plugin'
-    - run: gcloud container fleet memberships get-credentials ${{ vars.GKE_CLUTER_NAME }} --project=serca-tools
+    - run: gcloud container clusters get-credentials ${{ vars.GKE_CLUTER_NAME }} --location=${{ vars.LOCATION }} --project=${{ vars.PROJECT_ID }}
     - run: |
         kubectl set image deployment/${{ inputs.deployment }} ${{ inputs.container }}=${{ inputs.repository }}:${{ inputs.tag }} -n ${{ inputs.namespace }}
 


### PR DESCRIPTION
## Summary

Replace Fleet Connect Gateway authentication with direct GKE cluster credentials in `update_k8s_image.yml`, enabling deployments to legacy clusters that are not registered in the serca-tools Fleet.

## Changes

### Changed
- `update_k8s_image.yml`: replaced `gcloud container fleet memberships get-credentials <name> --project=serca-tools` with `gcloud container clusters get-credentials <name> --location=<location> --project=<project>`, reading `GKE_CLUTER_NAME`, `LOCATION`, and `PROJECT_ID` from the GitHub Actions environment

## Technical Details

The `cdip-prod01` legacy cluster (`sintegrate-4bb07e9c` in `cdip-prod1-78ca`) has never been registered in the serca-tools Fleet, causing `deploy_prod_legacy` to fail on every run. The environment already has `LOCATION` and `PROJECT_ID` variables — they just weren't being used. The new approach uses direct GKE credentials which work for any cluster accessible to the environment's service account, regardless of Fleet registration.

Tag `v8` should be created on this workflow after merge so cdip can reference it.

## Files Changed

**1 file changed, 1 insertion(+), 1 deletion(-)**

---
**Jira**: https://allenai.atlassian.net/browse/DASOPS-2057